### PR TITLE
[#10959] Paginate frontend call to webapi for large course

### DIFF
--- a/src/web/app/components/loader-bar/loader-bar.component.scss
+++ b/src/web/app/components/loader-bar/loader-bar.component.scss
@@ -7,7 +7,7 @@
 }
 
 /* stylelint-disable selector-pseudo-element-no-unknown */
-::ng-deep .progress {
+:host ::ng-deep .progress {
   border-radius: 0;
   height: .25rem;
 }

--- a/src/web/app/components/progress-bar/progress-bar.component.html
+++ b/src/web/app/components/progress-bar/progress-bar.component.html
@@ -1,0 +1,4 @@
+<div>
+  <ngb-progressbar type="info" height="26px" showValue="true" [value]="100" [striped]="true" [animated]="true"></ngb-progressbar>
+</div>
+  

--- a/src/web/app/components/progress-bar/progress-bar.component.html
+++ b/src/web/app/components/progress-bar/progress-bar.component.html
@@ -1,3 +1,3 @@
 <div>
-  <ngb-progressbar type="info" height="26px" showValue="true" [value]="100" [striped]="true" [animated]="true"></ngb-progressbar>
+  <ngb-progressbar type="info" height="26px" showValue="true" [value]="progressPercentage" [striped]="true" [animated]="true"></ngb-progressbar>
 </div>

--- a/src/web/app/components/progress-bar/progress-bar.component.html
+++ b/src/web/app/components/progress-bar/progress-bar.component.html
@@ -1,4 +1,3 @@
 <div>
   <ngb-progressbar type="info" height="26px" showValue="true" [value]="100" [striped]="true" [animated]="true"></ngb-progressbar>
 </div>
-  

--- a/src/web/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressBarComponent } from './progress-bar.component';
+
+describe('ProgressBarComponent', () => {
+  let component: ProgressBarComponent;
+  let fixture: ComponentFixture<ProgressBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProgressBarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProgressBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.spec.ts
@@ -17,7 +17,7 @@ describe('ProgressBarComponent', () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/web/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.spec.ts
@@ -1,16 +1,14 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ProgressBarComponent } from "./progress-bar.component";
 
-import { ProgressBarComponent } from './progress-bar.component';
-
-describe('ProgressBarComponent', () => {
+describe("ProgressBarComponent", () => {
   let component: ProgressBarComponent;
   let fixture: ComponentFixture<ProgressBarComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ProgressBarComponent ]
-    })
-    .compileComponents();
+      declarations: [ProgressBarComponent],
+    }).compileComponents();
   }));
 
   beforeEach(() => {
@@ -19,7 +17,7 @@ describe('ProgressBarComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/web/app/components/progress-bar/progress-bar.component.spec.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.spec.ts
@@ -1,7 +1,7 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { ProgressBarComponent } from "./progress-bar.component";
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProgressBarComponent } from './progress-bar.component';
 
-describe("ProgressBarComponent", () => {
+describe('ProgressBarComponent', () => {
   let component: ProgressBarComponent;
   let fixture: ComponentFixture<ProgressBarComponent>;
 

--- a/src/web/app/components/progress-bar/progress-bar.component.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ProgressBarService } from '../../../services/progress-bar.service';
 
 /**
  * Progress bar used to show download progress.
@@ -10,9 +11,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ProgressBarComponent implements OnInit {
 
-  constructor() { }
+  progressPercentage: number = 0;
+
+  constructor(private progressBarService: ProgressBarService) { }
 
   ngOnInit(): void {
+    this.getProgress();
   }
-
+  
+  getProgress(): void {
+    this.progressBarService.progressPercentage.subscribe((progressPercentage) => {
+      this.progressPercentage = progressPercentage;
+    })
+  }
 }

--- a/src/web/app/components/progress-bar/progress-bar.component.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.ts
@@ -18,10 +18,10 @@ export class ProgressBarComponent implements OnInit {
   ngOnInit(): void {
     this.getProgress();
   }
-  
+
   getProgress(): void {
-    this.progressBarService.progressPercentage.subscribe((progressPercentage) => {
+    this.progressBarService.progressPercentage.subscribe((progressPercentage: number) => {
       this.progressPercentage = progressPercentage;
-    })
+    });
   }
 }

--- a/src/web/app/components/progress-bar/progress-bar.component.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'tm-progress-bar',
+  templateUrl: './progress-bar.component.html',
+  styleUrls: ['./progress-bar.component.scss']
+})
+export class ProgressBarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/web/app/components/progress-bar/progress-bar.component.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.ts
@@ -1,9 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 
+/**
+ * Progress bar used to show download progress.
+ */
 @Component({
   selector: 'tm-progress-bar',
   templateUrl: './progress-bar.component.html',
-  styleUrls: ['./progress-bar.component.scss']
+  styleUrls: ['./progress-bar.component.scss'],
 })
 export class ProgressBarComponent implements OnInit {
 

--- a/src/web/app/components/progress-bar/progress-bar.module.ts
+++ b/src/web/app/components/progress-bar/progress-bar.module.ts
@@ -1,6 +1,6 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { NgbProgressbarModule } from '@ng-bootstrap/ng-bootstrap';
-import { CommonModule } from '@angular/common';
 import { ProgressBarComponent } from './progress-bar.component';
 
 /**
@@ -10,7 +10,7 @@ import { ProgressBarComponent } from './progress-bar.component';
   declarations: [ProgressBarComponent],
   imports: [
     NgbProgressbarModule,
-    CommonModule
+    CommonModule,
   ],
   exports: [
     ProgressBarComponent,

--- a/src/web/app/components/progress-bar/progress-bar.module.ts
+++ b/src/web/app/components/progress-bar/progress-bar.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { NgbProgressbarModule } from '@ng-bootstrap/ng-bootstrap';
+import { CommonModule } from '@angular/common';
+import { ProgressBarComponent } from './progress-bar.component';
+
+/**
+ * Module for progress bar used to show download progress.
+ */
+@NgModule({
+  declarations: [ProgressBarComponent],
+  imports: [
+    NgbProgressbarModule,
+    CommonModule
+  ],
+  exports: [
+    ProgressBarComponent,
+  ],
+})
+export class ProgressBarModule { }

--- a/src/web/app/components/simple-modal/simple-modal-type.ts
+++ b/src/web/app/components/simple-modal/simple-modal-type.ts
@@ -18,4 +18,8 @@ export enum SimpleModalType {
    * Neutral modal.
    */
   NEUTRAL,
+  /**
+   * Load modal.
+   */
+  LOAD,
 }

--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -2,13 +2,13 @@
      [ngClass]="{
      'alert-danger' : type === SimpleModalType.DANGER,
      'alert-warning' : type === SimpleModalType.WARNING,
-     'alert-info' : type === SimpleModalType.INFO,
+     'alert-info' : type === SimpleModalType.INFO || SimpleModalType.LOAD,
      'bg-white' : type === SimpleModalType.NEUTRAL}">
   <div>
     <h5 class="modal-title">
       <i *ngIf="type === SimpleModalType.DANGER" class="fas fa-times-circle"></i>
       <i *ngIf="type === SimpleModalType.WARNING" class="fas fa-exclamation-circle"></i>
-      <i *ngIf="type === SimpleModalType.INFO" class="fas fa-info-circle"></i>
+      <i *ngIf="type === SimpleModalType.INFO || SimpleModalType.LOAD" class="fas fa-info-circle"></i>
       <span class="margin-left-5px" [innerHTML]="header"></span>
     </h5>
   </div>
@@ -21,6 +21,9 @@
     <ng-container *ngTemplateOutlet="content"></ng-container>
   </div>
   <div *ngIf="!isTemplate" [innerHTML]="content"></div>
+  <div class="progress-bar-container">
+    <tm-progress-bar></tm-progress-bar>
+  </div>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-light modal-btn-cancel" *ngIf="!isInformationOnly" (click)="activeModal.dismiss()">
@@ -28,7 +31,7 @@
   </button>
   <button type="button" class="btn modal-btn-ok"
           [ngClass]="{
-          'btn-danger' : type === SimpleModalType.DANGER,
+          'btn-danger' : type === SimpleModalType.DANGER || SimpleModalType.LOAD,
           'btn-warning' : type === SimpleModalType.WARNING,
           'btn-info' : type === SimpleModalType.INFO,
           'btn-primary' : type === SimpleModalType.NEUTRAL }"

--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -2,13 +2,13 @@
      [ngClass]="{
      'alert-danger' : type === SimpleModalType.DANGER,
      'alert-warning' : type === SimpleModalType.WARNING,
-     'alert-info' : type === SimpleModalType.INFO || SimpleModalType.LOAD,
+     'alert-info' : type === SimpleModalType.INFO || type === SimpleModalType.LOAD,
      'bg-white' : type === SimpleModalType.NEUTRAL}">
   <div>
     <h5 class="modal-title">
       <i *ngIf="type === SimpleModalType.DANGER" class="fas fa-times-circle"></i>
       <i *ngIf="type === SimpleModalType.WARNING" class="fas fa-exclamation-circle"></i>
-      <i *ngIf="type === SimpleModalType.INFO || SimpleModalType.LOAD" class="fas fa-info-circle"></i>
+      <i *ngIf="type === SimpleModalType.INFO || type === SimpleModalType.LOAD" class="fas fa-info-circle"></i>
       <span class="margin-left-5px" [innerHTML]="header"></span>
     </h5>
   </div>
@@ -21,7 +21,7 @@
     <ng-container *ngTemplateOutlet="content"></ng-container>
   </div>
   <div *ngIf="!isTemplate" [innerHTML]="content"></div>
-  <div class="progress-bar-container">
+  <div *ngIf="type === SimpleModalType.LOAD" class="progress-bar-container">
     <tm-progress-bar></tm-progress-bar>
   </div>
 </div>
@@ -31,7 +31,7 @@
   </button>
   <button type="button" class="btn modal-btn-ok"
           [ngClass]="{
-          'btn-danger' : type === SimpleModalType.DANGER || SimpleModalType.LOAD,
+          'btn-danger' : type === SimpleModalType.DANGER || type === SimpleModalType.LOAD,
           'btn-warning' : type === SimpleModalType.WARNING,
           'btn-info' : type === SimpleModalType.INFO,
           'btn-primary' : type === SimpleModalType.NEUTRAL }"

--- a/src/web/app/components/simple-modal/simple-modal.component.scss
+++ b/src/web/app/components/simple-modal/simple-modal.component.scss
@@ -1,3 +1,8 @@
 .margin-left-5px {
   margin-left: 5px;
 }
+
+.progress-bar-container {
+  margin-top: 10px;
+  margin-bottom: 2px;
+}

--- a/src/web/app/components/simple-modal/simple-modal.module.ts
+++ b/src/web/app/components/simple-modal/simple-modal.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { SimpleModalComponent } from './simple-modal.component';
 import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
+import { SimpleModalComponent } from './simple-modal.component';
 
 /**
  * Module for the modal component
@@ -11,7 +11,7 @@ import { ProgressBarModule } from '../../components/progress-bar/progress-bar.mo
   exports: [SimpleModalComponent],
   imports: [
     CommonModule,
-    ProgressBarModule
+    ProgressBarModule,
   ],
   entryComponents: [SimpleModalComponent],
 })

--- a/src/web/app/components/simple-modal/simple-modal.module.ts
+++ b/src/web/app/components/simple-modal/simple-modal.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SimpleModalComponent } from './simple-modal.component';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
 
 /**
  * Module for the modal component
@@ -10,6 +11,7 @@ import { SimpleModalComponent } from './simple-modal.component';
   exports: [SimpleModalComponent],
   imports: [
     CommonModule,
+    ProgressBarModule
   ],
   entryComponents: [SimpleModalComponent],
 })

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -134,19 +134,19 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
     InstructorSessionNoResponsePanelComponent;
 
   constructor(private feedbackSessionsService: FeedbackSessionsService,
-    private feedbackQuestionsService: FeedbackQuestionsService,
-    private courseService: CourseService,
-    private studentService: StudentService,
-    private instructorService: InstructorService,
-    private route: ActivatedRoute,
-    private timezoneService: TimezoneService,
-    private simpleModalService: SimpleModalService,
-    private commentsToCommentTableModel: CommentsToCommentTableModelPipe,
-    private progressBarService: ProgressBarService,
-    statusMessageService: StatusMessageService,
-    commentService: FeedbackResponseCommentService,
-    commentToCommentRowModel: CommentToCommentRowModelPipe,
-    tableComparatorService: TableComparatorService) {
+              private feedbackQuestionsService: FeedbackQuestionsService,
+              private courseService: CourseService,
+              private studentService: StudentService,
+              private instructorService: InstructorService,
+              private route: ActivatedRoute,
+              private timezoneService: TimezoneService,
+              private simpleModalService: SimpleModalService,
+              private commentsToCommentTableModel: CommentsToCommentTableModelPipe,
+              private progressBarService: ProgressBarService,
+              statusMessageService: StatusMessageService,
+              commentService: FeedbackResponseCommentService,
+              commentToCommentRowModel: CommentToCommentRowModelPipe,
+              tableComparatorService: TableComparatorService) {
     super(commentToCommentRowModel, commentService, statusMessageService, tableComparatorService);
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
   }
@@ -171,12 +171,12 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
     }).subscribe((feedbackSession: FeedbackSession) => {
       this.session = feedbackSession;
       this.formattedSessionOpeningTime = this.timezoneService
-        .formatToString(this.session.submissionStartTimestamp, this.session.timeZone, TIME_FORMAT);
+          .formatToString(this.session.submissionStartTimestamp, this.session.timeZone, TIME_FORMAT);
       this.formattedSessionClosingTime = this.timezoneService
-        .formatToString(this.session.submissionEndTimestamp, this.session.timeZone, TIME_FORMAT);
+          .formatToString(this.session.submissionEndTimestamp, this.session.timeZone, TIME_FORMAT);
       if (this.session.resultVisibleFromTimestamp) {
         this.formattedResultVisibleFromTime = this.timezoneService
-          .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, TIME_FORMAT);
+            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, TIME_FORMAT);
       } else {
         this.formattedResultVisibleFromTime = 'Not applicable';
       }
@@ -289,18 +289,18 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       feedbackSessionName: this.session.feedbackSessionName,
       intent: Intent.INSTRUCTOR_RESULT,
     })
-      .subscribe((resp: SessionResults) => {
-        if (resp.questions.length) {
-          const responses: QuestionOutput = resp.questions[0];
-          this.questionsModel[questionId].responses = responses.allResponses;
-          this.questionsModel[questionId].statistics = responses.questionStatistics;
-          this.questionsModel[questionId].hasPopulated = true;
+        .subscribe((resp: SessionResults) => {
+          if (resp.questions.length) {
+            const responses: QuestionOutput = resp.questions[0];
+            this.questionsModel[questionId].responses = responses.allResponses;
+            this.questionsModel[questionId].statistics = responses.questionStatistics;
+            this.questionsModel[questionId].hasPopulated = true;
 
-          this.preprocessComments(responses.allResponses);
-        }
-      }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorToast(resp.error.message);
-      });
+            this.preprocessComments(responses.allResponses);
+          }
+        }, (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        });
   }
 
   /**
@@ -327,19 +327,19 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       intent: Intent.INSTRUCTOR_RESULT,
       groupBySection: sectionName,
     })
-      .subscribe((resp: SessionResults) => {
-        this.sectionsModel[sectionName].questions = resp.questions;
-        this.sectionsModel[sectionName].hasPopulated = true;
+        .subscribe((resp: SessionResults) => {
+          this.sectionsModel[sectionName].questions = resp.questions;
+          this.sectionsModel[sectionName].hasPopulated = true;
 
-        // sort questions by question number
-        resp.questions.sort((a: QuestionOutput, b: QuestionOutput) =>
-          a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
-        resp.questions.forEach((question: QuestionOutput) => {
-          this.preprocessComments(question.allResponses);
+          // sort questions by question number
+          resp.questions.sort((a: QuestionOutput, b: QuestionOutput) =>
+            a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
+          resp.questions.forEach((question: QuestionOutput) => {
+            this.preprocessComments(question.allResponses);
+          });
+        }, (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
-      }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorToast(resp.error.message);
-      });
   }
 
   /**
@@ -351,7 +351,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
   preprocessComments(responses: ResponseOutput[]): void {
     responses.forEach((response: ResponseOutput) => {
       this.instructorCommentTableModel[response.responseId] =
-        this.commentsToCommentTableModel.transform(response.instructorComments, false, this.session.timeZone);
+         this.commentsToCommentTableModel.transform(response.instructorComments, false, this.session.timeZone);
       this.sortComments(this.instructorCommentTableModel[response.responseId]);
       // clear the original comments for safe as instructorCommentTableModel will become the single point of truth
       response.instructorComments = [];
@@ -368,23 +368,23 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       const modalContent: string = `An email will be sent to students to inform them that the session has been unpublished and the session responses
           will no longer be viewable by students.`;
       modalRef = this.simpleModalService.openConfirmationModal(
-        `Unpublish this session <strong>${this.session.feedbackSessionName}</strong>?`,
-        SimpleModalType.WARNING, modalContent);
+          `Unpublish this session <strong>${this.session.feedbackSessionName}</strong>?`,
+          SimpleModalType.WARNING, modalContent);
     } else {
       const modalContent: string = 'An email will be sent to students to inform them that the responses are ready for viewing.';
       modalRef = this.simpleModalService.openConfirmationModal(
-        `Publish this session <strong>${this.session.feedbackSessionName}</strong>?`,
-        SimpleModalType.WARNING, modalContent);
+          `Publish this session <strong>${this.session.feedbackSessionName}</strong>?`,
+          SimpleModalType.WARNING, modalContent);
     }
 
     modalRef.result.then(() => {
       const response: Observable<any> = isPublished ?
-        this.feedbackSessionsService.unpublishFeedbackSession(
-          this.session.courseId, this.session.feedbackSessionName,
-        ) :
-        this.feedbackSessionsService.publishFeedbackSession(
-          this.session.courseId, this.session.feedbackSessionName,
-        );
+          this.feedbackSessionsService.unpublishFeedbackSession(
+            this.session.courseId, this.session.feedbackSessionName,
+          ) :
+          this.feedbackSessionsService.publishFeedbackSession(
+            this.session.courseId, this.session.feedbackSessionName,
+          );
 
       response.subscribe((res: FeedbackSession) => {
         this.session = res;
@@ -422,27 +422,27 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
 
     let numberOfQuestionsDownloaded: number = 0;
     const modalContent: string =
-      'Downloading the results of your feedback session...';
+        'Downloading the results of your feedback session...';
     const downloadModalRef: NgbModalRef = this.simpleModalService.openDownloadModal(
-      'Download Progress', SimpleModalType.LOAD, modalContent);
+        'Download Progress', SimpleModalType.LOAD, modalContent);
     downloadModalRef.result.then(() => {
       this.isDownloadingResults = false;
       downloadAborted = true;
     });
 
     concat(
-      ...Object.keys(this.questionsModel).map((k: string) =>
-        this.feedbackSessionsService.downloadSessionResults(
-          this.session.courseId,
-          this.session.feedbackSessionName,
-          Intent.INSTRUCTOR_RESULT,
-          this.indicateMissingResponses,
-          this.showStatistics,
-          this.questionsModel[k].question.feedbackQuestionId,
-          this.section.length === 0 ? undefined : this.section,
-          this.section.length === 0 ? undefined : this.sectionType,
+        ...Object.keys(this.questionsModel).map((k: string) =>
+          this.feedbackSessionsService.downloadSessionResults(
+              this.session.courseId,
+              this.session.feedbackSessionName,
+              Intent.INSTRUCTOR_RESULT,
+              this.indicateMissingResponses,
+              this.showStatistics,
+              this.questionsModel[k].question.feedbackQuestionId,
+              this.section.length === 0 ? undefined : this.section,
+              this.section.length === 0 ? undefined : this.sectionType,
+          ),
         ),
-      ),
     ).pipe(finalize(() => this.isDownloadingResults = false))
       .pipe(takeWhile(() => this.isDownloadingResults))
       .subscribe({
@@ -470,15 +470,15 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
 
   downloadQuestionResultHandler(question: { questionNumber: number, questionId: string }): void {
     const filename: string =
-      `${this.session.courseId}_${this.session.feedbackSessionName}_question${question.questionNumber}.csv`;
+        `${this.session.courseId}_${this.session.feedbackSessionName}_question${question.questionNumber}.csv`;
 
     this.feedbackSessionsService.downloadSessionResults(
-      this.session.courseId,
-      this.session.feedbackSessionName,
-      Intent.INSTRUCTOR_RESULT,
-      this.indicateMissingResponses,
-      this.showStatistics,
-      question.questionId,
+        this.session.courseId,
+        this.session.feedbackSessionName,
+        Intent.INSTRUCTOR_RESULT,
+        this.indicateMissingResponses,
+        this.showStatistics,
+        question.questionId,
     ).subscribe((resp: string) => {
       const blob: any = new Blob([resp], { type: 'text/csv' });
       saveAs(blob, filename);

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -400,7 +400,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       }, (resp: ErrorMessageOutput) => {
         this.statusMessageService.showErrorToast(resp.error.message);
       });
-    }, () => { });
+    }, () => {});
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -289,18 +289,18 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       feedbackSessionName: this.session.feedbackSessionName,
       intent: Intent.INSTRUCTOR_RESULT,
     })
-        .subscribe((resp: SessionResults) => {
-          if (resp.questions.length) {
-            const responses: QuestionOutput = resp.questions[0];
-            this.questionsModel[questionId].responses = responses.allResponses;
-            this.questionsModel[questionId].statistics = responses.questionStatistics;
-            this.questionsModel[questionId].hasPopulated = true;
+    .subscribe((resp: SessionResults) => {
+      if (resp.questions.length) {
+        const responses: QuestionOutput = resp.questions[0];
+        this.questionsModel[questionId].responses = responses.allResponses;
+        this.questionsModel[questionId].statistics = responses.questionStatistics;
+        this.questionsModel[questionId].hasPopulated = true;
 
-            this.preprocessComments(responses.allResponses);
-          }
-        }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorToast(resp.error.message);
-        });
+        this.preprocessComments(responses.allResponses);
+      }
+    }, (resp: ErrorMessageOutput) => {
+      this.statusMessageService.showErrorToast(resp.error.message);
+    });
   }
 
   /**
@@ -327,19 +327,19 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       intent: Intent.INSTRUCTOR_RESULT,
       groupBySection: sectionName,
     })
-        .subscribe((resp: SessionResults) => {
-          this.sectionsModel[sectionName].questions = resp.questions;
-          this.sectionsModel[sectionName].hasPopulated = true;
+    .subscribe((resp: SessionResults) => {
+      this.sectionsModel[sectionName].questions = resp.questions;
+      this.sectionsModel[sectionName].hasPopulated = true;
 
-          // sort questions by question number
-          resp.questions.sort((a: QuestionOutput, b: QuestionOutput) =>
-            a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
-          resp.questions.forEach((question: QuestionOutput) => {
-            this.preprocessComments(question.allResponses);
-          });
-        }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorToast(resp.error.message);
-        });
+      // sort questions by question number
+      resp.questions.sort((a: QuestionOutput, b: QuestionOutput) =>
+        a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
+      resp.questions.forEach((question: QuestionOutput) => {
+        this.preprocessComments(question.allResponses);
+      });
+    }, (resp: ErrorMessageOutput) => {
+      this.statusMessageService.showErrorToast(resp.error.message);
+    });
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -384,8 +384,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
         ) :
         this.feedbackSessionsService.publishFeedbackSession(
           this.session.courseId, this.session.feedbackSessionName,
-        )
-        ;
+        );
 
       response.subscribe((res: FeedbackSession) => {
         this.session = res;
@@ -423,7 +422,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
 
     let numberOfQuestionsDownloaded: number = 0;
     const modalContent: string =
-      `Downloading the results of your feedback session...`;
+      'Downloading the results of your feedback session...';
     const downloadModalRef: NgbModalRef = this.simpleModalService.openDownloadModal(
       'Download Progress', SimpleModalType.LOAD, modalContent);
     downloadModalRef.result.then(() => {
@@ -450,8 +449,8 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
         next: (resp: string) => {
           out.push(resp);
           numberOfQuestionsDownloaded += 1;
-          const totalNumberOfQuestions = Object.keys(this.questionsModel).length;
-          const progressPercentage = Math.round(100 * numberOfQuestionsDownloaded / totalNumberOfQuestions);
+          const totalNumberOfQuestions: number = Object.keys(this.questionsModel).length;
+          const progressPercentage: number = Math.round(100 * numberOfQuestionsDownloaded / totalNumberOfQuestions);
           this.progressBarService.updateProgress(progressPercentage);
         },
         complete: () => {

--- a/src/web/services/progress-bar.service.spec.ts
+++ b/src/web/services/progress-bar.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProgressBarService } from './progress-bar.service';
+
+describe('ProgressBarService', () => {
+  let service: ProgressBarService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ProgressBarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/web/services/progress-bar.service.ts
+++ b/src/web/services/progress-bar.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * Service to handle display of the download progress bar
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ProgressBarService {
+
+  progressPercentage: Subject<number> = new Subject<number>();
+
+  constructor() { }
+
+  /**
+   * Update the progress percentage on the progress bar.
+   */
+  updateProgress(progressPercentage: number): void {
+    this.progressPercentage.next(progressPercentage);
+  }
+
+}

--- a/src/web/services/progress-bar.service.ts
+++ b/src/web/services/progress-bar.service.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
  * Service to handle display of the download progress bar
  */
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ProgressBarService {
 


### PR DESCRIPTION
Part of #10959, follow-up to PR https://github.com/TEAMMATES/teammates/pull/10960

**Outline of Solution**

- Created component for `progress-bar`, added a service to handle the data flow
- Added `progress-bar` component as a child of `simple-modal` component
- Added a new type of `simple-modal`, `SimpleModalType.LOAD`, that displays the `progress-bar`

![stuff](https://user-images.githubusercontent.com/46853051/108107680-86128f00-70ca-11eb-8f96-ffba0a988bb8.gif)
The test data used involved 600 students, 50 questions.

**Remarks**
- When the download size is small, the progress bar still loads smoothly so it doesn't look jittery - the progress bar just fills up very quickly. 
- I changed the color of Abort button from the primary color to danger color to indicate to the user that clicking the button is not the default action (unlike the usual `INFO` modal)
- I will pull the latest changes from upstream after review, before merging

