### PR TITLE
Add transparent overlay  for loading modal

### DIFF
--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -1,5 +1,5 @@
-<div class="modal-header"
-     [ngClass]="{
+<div class="transparent-overlay" [ngClass]="{ 'display-none': type !== SimpleModalType.LOAD }"></div>
+<div class="modal-header" [ngClass]="{
      'alert-danger' : type === SimpleModalType.DANGER,
      'alert-warning' : type === SimpleModalType.WARNING,
      'alert-info' : type === SimpleModalType.INFO || type === SimpleModalType.LOAD,

--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -1,5 +1,6 @@
 <div class="transparent-overlay" [ngClass]="{ 'display-none': type !== SimpleModalType.LOAD }"></div>
-<div class="modal-header" [ngClass]="{
+<div class="modal-header" 
+     [ngClass]="{
      'alert-danger' : type === SimpleModalType.DANGER,
      'alert-warning' : type === SimpleModalType.WARNING,
      'alert-info' : type === SimpleModalType.INFO || type === SimpleModalType.LOAD,

--- a/src/web/app/components/simple-modal/simple-modal.component.scss
+++ b/src/web/app/components/simple-modal/simple-modal.component.scss
@@ -6,3 +6,17 @@
   margin-top: 10px;
   margin-bottom: 2px;
 }
+
+.transparent-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  visibility: false;
+  z-index: -1;
+}
+
+.display-none {
+  display: none;
+}


### PR DESCRIPTION
Part of #10959, follow up to #20

**Outline of Solution**

- Add a transparent overlay for `SimpleModalType.LOAD` modals
- The modal prevents users from clicking on background UI elements while the loading is in progress
