### PR TITLE
Terminate download when X button is pressed

### DIFF
--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -13,7 +13,8 @@
       <span class="margin-left-5px" [innerHTML]="header"></span>
     </h5>
   </div>
-  <button type="button" class="close" (click)="activeModal.dismiss()">
+  <button type="button" class="close" 
+    (click)="type === SimpleModalType.LOAD ? activeModal.close() : activeModal.dismiss()">
     <i class="fas fa-times"></i>
   </button>
 </div>

--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -13,7 +13,7 @@
       <span class="margin-left-5px" [innerHTML]="header"></span>
     </h5>
   </div>
-  <button type="button" class="close" 
+  <button type="button" class="close"
     (click)="type === SimpleModalType.LOAD ? activeModal.close() : activeModal.dismiss()">
     <i class="fas fa-times"></i>
   </button>


### PR DESCRIPTION
**Outline of Solution**
- Modify the behavior of X button to terminate the download

**Remarks**
Below is a record of the thought process, in case anyone revisits this part of the code.
- Originally, X button does not terminate the download. The rationale was: 
1. If the user intentionally wants to close the modal to view other parts of the page while waiting, they can do so by intentionally hitting the X button. 
2. To avoid having two different looking UI components display the same behavior (Intuitively, things that look different should do different things)
- Rationale for the change is to prevent weird UI interactions that may occur as a result of users messing around with UI during the download